### PR TITLE
feat: add support for alternative data-testid

### DIFF
--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -6,7 +6,7 @@ export function removeDataTestIdTransformer<
   return context => {
     const visit: ts.Visitor = node => {
       if (ts.isJsxAttribute(node)) {
-        if (node.name.getText() === 'data-test-id') {
+        if (node.name.getText() === 'data-test-id' || node.name.getText() === 'data-testid') {
           return undefined;
         }
       }

--- a/test/transformer.test.ts
+++ b/test/transformer.test.ts
@@ -41,3 +41,8 @@ test('does not remove data-test-id inside a string', () => {
   source = 'const b = \'<div data-test-id="test-id"></div>\';';
   expect(transform(source)).toBe(source);
 });
+
+test('removes data-testid pattern', () => {
+  const source = '<div><span data-testid="test-el">nested</span></div>;';
+  expect(transform(source)).toBe('<div><span>nested</span></div>;');
+});


### PR DESCRIPTION
This plugin is almost perfect for my usecase, but because we have standardised on data-testid it doesn't work OOB.

making this simple change will make the plugin usable for us without needing to fork.